### PR TITLE
UI fixes

### DIFF
--- a/src/HeadsetControlQt/headsetcontrolqt.cpp
+++ b/src/HeadsetControlQt/headsetcontrolqt.cpp
@@ -400,14 +400,34 @@ void HeadsetControlQt::updateUIWithHeadsetInfo(const QJsonObject &headsetInfo)
 void HeadsetControlQt::noDeviceFound()
 {
     toggleUIElements(false);
-    trayIcon->setToolTip("No Device Found");
+    trayIcon->setToolTip(tr("No Device Found"));
+    QString iconPath = getBatteryIcon(0, false, true, ui->themeComboBox->currentIndex());
+#ifdef _WIN32
+    trayIcon->setIcon(QIcon(iconPath));
+#elif __linux__
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString desktop = env.value("XDG_CURRENT_DESKTOP");
+    if (desktop.contains("KDE", Qt::CaseInsensitive)) {
+        QString kdeVersion = getKDEPlasmaVersion();
+        if (kdeVersion.startsWith("5")) {
+            trayIcon->setIcon(QIcon(iconPath));
+        } else if (kdeVersion.startsWith("6")) {
+            trayIcon->setIcon(QIcon::fromTheme(iconPath));
+        } else {
+            trayIcon->setIcon(QIcon(iconPath));
+        }
+    }
+#endif
 }
 
 void HeadsetControlQt::toggleUIElements(bool show)
 {
+    ui->settingsLabel->setVisible(show);
     ui->frame->setVisible(show);
+    ui->deviceLabel->setVisible(show);
     ui->frame_2->setVisible(show);
     ui->notFoundLabel->setVisible(!show);
+    this->setFixedSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
     this->setMinimumSize(380, 0);
     this->adjustSize();
     this->setFixedSize(this->size());
@@ -482,7 +502,7 @@ void HeadsetControlQt::trayIconActivated(QSystemTrayIcon::ActivationReason reaso
 
 void HeadsetControlQt::closeEvent(QCloseEvent *event)
 {
-    trayIcon->contextMenu()->actions().first()->setText("Show");
+    trayIcon->contextMenu()->actions().first()->setText(tr("Show"));
     sendFirstMinimizeNotification();
 
 }

--- a/src/HeadsetControlQt/headsetcontrolqt.ui
+++ b/src/HeadsetControlQt/headsetcontrolqt.ui
@@ -195,7 +195,7 @@
      </widget>
     </item>
     <item row="2" column="0">
-     <widget class="QLabel" name="label_4">
+     <widget class="QLabel" name="settingsLabel">
       <property name="minimumSize">
        <size>
         <width>0</width>

--- a/src/Resources/tr/HeadsetControl-Qt_en.ts
+++ b/src/Resources/tr/HeadsetControl-Qt_en.ts
@@ -5,7 +5,7 @@
     <name>HeadsetControlQt</name>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.ui" line="26"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>HeadsetControl-Qt</source>
         <translation></translation>
     </message>
@@ -86,7 +86,8 @@
     </message>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="130"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="469"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="489"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="505"/>
         <source>Show</source>
         <translation></translation>
     </message>
@@ -116,12 +117,17 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="472"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="403"/>
+        <source>No Device Found</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="492"/>
         <source>Hide</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>The application is still running in the background.</source>
         <translation></translation>
     </message>

--- a/src/Resources/tr/HeadsetControl-Qt_fr.ts
+++ b/src/Resources/tr/HeadsetControl-Qt_fr.ts
@@ -5,7 +5,7 @@
     <name>HeadsetControlQt</name>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.ui" line="26"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>HeadsetControl-Qt</source>
         <translation></translation>
     </message>
@@ -86,7 +86,8 @@
     </message>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="130"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="469"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="489"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="505"/>
         <source>Show</source>
         <translation>Afficher</translation>
     </message>
@@ -116,12 +117,17 @@
         <translation>Pas de casque connecté</translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="472"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="403"/>
+        <source>No Device Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="492"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>The application is still running in the background.</source>
         <translation>L&apos;application tourne toujours en arrière plan.</translation>
     </message>

--- a/src/Resources/tr/HeadsetControl-Qt_hu.ts
+++ b/src/Resources/tr/HeadsetControl-Qt_hu.ts
@@ -5,7 +5,7 @@
     <name>HeadsetControlQt</name>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.ui" line="26"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>HeadsetControl-Qt</source>
         <translation></translation>
     </message>
@@ -86,7 +86,8 @@
     </message>
     <message>
         <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="130"/>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="469"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="489"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="505"/>
         <source>Show</source>
         <translation>Mutat</translation>
     </message>
@@ -116,12 +117,17 @@
         <translation>Nincs csatlakoztatva fejhallgató</translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="472"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="403"/>
+        <source>No Device Found</source>
+        <translation>Eszköz nem található</translation>
+    </message>
+    <message>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="492"/>
         <source>Hide</source>
         <translation>Elrejt</translation>
     </message>
     <message>
-        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="493"/>
+        <location filename="../../HeadsetControlQt/headsetcontrolqt.cpp" line="513"/>
         <source>The application is still running in the background.</source>
         <translation>Az alkalmazás továbbra is fut a háttérben.</translation>
     </message>


### PR DESCRIPTION
- fix handling form resize on device connect/disconnect
  This is how it looks when the program was started before the wireless adapter was connected:
  The adapter is now connected, the window cannot size is fixed. This happens both in Linux and Windows
  ![Screenshot 2024-09-14 174607](https://github.com/user-attachments/assets/e31f91c1-48e6-4b39-a26f-cf63415fde19)

- hide the device and settings labels, when no device is found
- update trayicon on device disconnect: before the icon showed the last state before disconnect, now shows the disconnected state icon
- make "No Device Found" text translatable
- "Show" text now also translatable in the HeadsetControlQt::closeEvent()


