### PR TITLE
fix: use qOverload to resolve ambiguous signal connections

### DIFF
--- a/HeadsetControl-Qt.pro
+++ b/HeadsetControl-Qt.pro
@@ -50,7 +50,7 @@ CONFIG += embed_translations
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/$${TARGET}/bin
+else: unix:!android: target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target
 
 # Define the source directory and the target directory in the build folder

--- a/HeadsetControl-Qt.pro
+++ b/HeadsetControl-Qt.pro
@@ -50,7 +50,7 @@ CONFIG += embed_translations
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/bin
+else: unix:!android: target.path = /bin
 !isEmpty(target.path): INSTALLS += target
 
 # Define the source directory and the target directory in the build folder

--- a/HeadsetControl-Qt.pro
+++ b/HeadsetControl-Qt.pro
@@ -50,7 +50,7 @@ CONFIG += embed_translations
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
+else: unix:!android: target.path = /usr/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
 # Define the source directory and the target directory in the build folder

--- a/HeadsetControlQt/HeadsetControlQt.cpp
+++ b/HeadsetControlQt/HeadsetControlQt.cpp
@@ -107,10 +107,10 @@ void HeadsetControlQt::setupUIConnections()
     connect(ui->notificationBatteryCheckBox, &QCheckBox::stateChanged, this, &HeadsetControlQt::saveSettings);
     connect(ui->startupCheckbox, &QCheckBox::stateChanged, this, &HeadsetControlQt::onStartupCheckBoxStateChanged);
     connect(ui->sidetoneSlider, &QSlider::sliderReleased, this, &HeadsetControlQt::onSidetoneSliderSliderReleased);
-    connect(ui->themeComboBox, &QComboBox::currentIndexChanged, this, &HeadsetControlQt::onThemeComboBoxCurrentIndexChanged);
-    connect(ui->lowBatteryThresholdSpinBox, &QSpinBox::valueChanged, this, &HeadsetControlQt::saveSettings);
+    connect(ui->themeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &HeadsetControlQt::onThemeComboBoxCurrentIndexChanged);
+    connect(ui->lowBatteryThresholdSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &HeadsetControlQt::saveSettings);
     connect(ui->soundBatteryCheckBox, &QCheckBox::stateChanged, this, &HeadsetControlQt::saveSettings);
-    connect(ui->languageComboBox, &QComboBox::currentIndexChanged, this, &HeadsetControlQt::changeApplicationLanguage);
+    connect(ui->languageComboBox, qOverload<int>(&QComboBox::currentIndexChanged) , this, &HeadsetControlQt::changeApplicationLanguage);
 }
 
 void HeadsetControlQt::populateComboBoxes()


### PR DESCRIPTION
## Description
Fixes build errors caused by ambiguous signal connections in Qt. Both QSpinBox::valueChanged and QComboBox::currentIndexChanged have multiple overloads of their signals. This was resolved by using qOverload.

## Technical Details  
- Uses qOverload<int> for QSpinBox::valueChanged
- Uses qOverload<int> for QComboBox::currentIndexChanged
- Affects UI connections in HeadsetControlQt

## Environment
- Qt version: 5.15.16
- QMake version: 3.1

## Why?
The ambiguous signal connections were causing build errors since the compiler couldn't automatically select the correct overload. This is a known issue with Qt signal/slot connections that have overloaded signals.

## Testing
- [x] Builds successfully
- [x] UI functions (language, theme, etc.) work as expected