### PR TITLE
Add PKGBUILD and installation guide for Arch Linux

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,32 @@
+_pkgname="headsetcontrol-qt"
+pkgname="${_pkgname}-git"
+pkgver=v24.r1.g9dd20a1
+pkgrel=1
+pkgdesc="Qt GUI for headsetcontrol"
+arch=('x86_64')
+url='https://github.com/Odizinne/HeadsetControl-Qt.git'
+license=('GPL-3.0-or-later')
+makedepends=('git' 'qt6-tools')
+depends=('qt6-base')
+source=("git+${url}#branch=main")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "HeadsetControl-Qt"
+  git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {
+  mkdir -p "HeadsetControl-Qt/build"
+}
+
+build() {
+  cd "HeadsetControl-Qt/build"
+  qmake6 ..
+  make
+  mv HeadsetControl-Qt ${_pkgname} # rename package binary to package name
+}
+
+package() {
+  install -Dm755 "${srcdir}/HeadsetControl-Qt/build/${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,8 @@ arch=('x86_64')
 url='https://github.com/Odizinne/HeadsetControl-Qt.git'
 license=('GPL-3.0-or-later')
 makedepends=('git' 'qt6-tools')
-depends=('qt6-base')
+provides=("${_pkgname}=${pkgver}")
+depends=('qt6-base' 'headsetcontrol')
 source=("git+${url}#branch=main")
 sha256sums=('SKIP')
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ You need [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_
 ### Linux
 
 Linux binaries are built on ubuntu 24.04 with Qt 6.4.2.  
-You need latest [headsetcontrol](https://github.com/Sapd/HeadsetControl?tab=readme-ov-file#building) available in path.  
+You need latest [headsetcontrol](https://github.com/Sapd/HeadsetControl?tab=readme-ov-file#building) available in path. 
+
+### Installation on Arch Linux
+
+Arch Linux users can install the application using `makepkg`.
+
+```bash
+makepkg -si
+```
 
 ## To-do
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,18 @@ You need latest [headsetcontrol](https://github.com/Sapd/HeadsetControl?tab=read
 
 Arch Linux users can install the application using `makepkg`.
 
+First install `headsetcontrol` as a dependency. 
+```bash
+yay -S --asdeps headsetcontrol-git
+```
+Then, build and install the application:
+
 ```bash
 makepkg -si
+```
+The application is now ready to use.
+```bash
+ headsetcontrol-qt
 ```
 
 ## To-do


### PR DESCRIPTION
### Overview

This PR adds a `PKGBUILD` to allow building and installing the `headsetcontrol-qt` package on Arch Linux. Additionally, an installation guide has been added to the README to provide clear instructions for Arch Linux users.

### Changes

- Added a `PKGBUILD` file to build `headsetcontrol-qt` from source.
- Updated the README with instructions on how to install the package using `makepkg` on Arch Linux.

### Installation Instructions

For Arch Linux users, the following steps can now be followed

1. Clone the repository:
   ```bash
   git clone https://github.com/odizinne/headsetcontrol-qt.git
   cd headsetcontrol-qt
   yay -S --asdeps headsetcontrol-git
   makepkg -si
   ```

